### PR TITLE
Arch: update packages, improve GRUB helper, work around libvirt guest TAP devices triggering ntpd crashes

### DIFF
--- a/bin/lk-provision-arch.sh
+++ b/bin/lk-provision-arch.sh
@@ -365,9 +365,9 @@ lk_start_trace
     lk_tty_print "Checking udev rules"
     unset LK_FILE_REPLACE_NO_CHANGE
     for _FILE in \
-        "$LK_BASE/share/udev"/{keyboard-event,disable-webcam-sound}*.rules; do
+        "$LK_BASE/share/udev"/{keyboard-event,disable-webcam-sound,libvirt-guest-tap-unmanaged}*.rules; do
         FILE=${_FILE##*/}
-        FILE=/etc/udev/rules.d/82-${LK_PATH_PREFIX}${FILE/.template./.}
+        FILE=/etc/udev/rules.d/85-${LK_PATH_PREFIX}${FILE/.template./.}
         lk_install -m 00644 "$FILE"
         if [[ $_FILE == *.template.* ]]; then
             lk_file_replace "$FILE" < <(lk_expand_template "$_FILE")

--- a/lib/arch/packages.sh
+++ b/lib/arch/packages.sh
@@ -227,6 +227,8 @@ PAC_PACKAGES+=(
     zsh
 
     7zip
+    innoextract-
+    unshield-
     unzip
     wimlib
 
@@ -246,6 +248,7 @@ AUR_PACKAGES+=(
     powercap-:H
 
     ## Utilities
+    icdiff-
     ps_mem-
 )
 

--- a/lib/bash/include/core.sh
+++ b/lib/bash/include/core.sh
@@ -4465,6 +4465,17 @@ function lk_base64() {
     fi
 }
 
+# lk_hex [-d]
+function lk_hex() {
+    local decode=0
+    [[ ${1-} != -d ]] || decode=1
+    if ((decode)); then
+        xxd -r -p
+    else
+        xxd -p -c 0
+    fi
+}
+
 if ! lk_is_macos; then
     function lk_full_name() {
         getent passwd "${1:-$EUID}" | cut -d: -f5 | cut -d, -f1

--- a/lib/bash/include/linode.sh
+++ b/lib/bash/include/linode.sh
@@ -552,7 +552,7 @@ Example:
         $'\n'"$(lk_fold_quote_options -120 linode-cli "${ARGS[@]##ssh-??? * }")"
     lk_confirm "Proceed?" Y || return
     lk_tty_print "${VERBS[0]} Linode"
-    FILE=/tmp/$FUNCNAME-$1-$(lk_date %s).json
+    FILE=/tmp/$FUNCNAME-$1-$(lk_timestamp).json
     LINODES=$(linode-cli "${ARGS[@]}" | tee "$FILE") ||
         lk_pass rm -f "$FILE" || return
     lk_linode_flush_cache

--- a/lib/bash/include/prompt.sh
+++ b/lib/bash/include/prompt.sh
@@ -1,91 +1,119 @@
 #!/usr/bin/env bash
 
-function _lk_prompt_trap() {
-    if ((${_LK_PROMPT_DISPLAYED-0})) &&
-        [[ $BASH_COMMAND != "$PROMPT_COMMAND" ]]; then
-        if [[ -z ${_LK_PROMPT_LAST+1} ]]; then
-            _LK_PROMPT_LAST_START=$(lk_date %s)
-            _LK_PROMPT_LAST=($BASH_COMMAND)
-            return
-        fi
-        _LK_PROMPT_LAST[${#_LK_PROMPT_LAST[@]}]=';'
-        _LK_PROMPT_LAST+=($BASH_COMMAND)
+# _lk_prompt_trap_debug
+#
+# Collect commands for the next prompt string.
+function _lk_prompt_trap_debug() {
+    # Don't collect anything before the first prompt
+    if ((!_LK_PROMPT_SEEN)) || [[ $BASH_COMMAND == "$PROMPT_COMMAND" ]]; then
+        return
     fi
+
+    # Normalise arguments without unsafe expansion
+    local command=($BASH_COMMAND) IFS=' '
+    if [[ -z ${_LK_PROMPT+1} ]]; then
+        _LK_PROMPT_START=$(lk_timestamp)
+        _LK_PROMPT_FIRST=$command
+    fi
+    _LK_PROMPT[${#_LK_PROMPT[@]}]=${command[*]}
 }
 
+# _lk_prompt_command
+#
+# Create a prompt string with current time, last command, elapsed time, exit
+# status and Git status.
 function _lk_prompt_command() {
-    # "Thu May 06 15:02:32 ✔( )" is 24 characters wide
-    local STATUS=$? SECS PS=() STR LEN=24 IFS
-    # Append the last command to HISTFILE
+    local status=$? part parts=()
     history -a
-    # Suppress expansion of prompt strings
+    # Prevent unsafe prompt string expansion
     shopt -u promptvars
-    if [[ -n ${_LK_PROMPT_LAST+1} ]]; then
-        SECS=$(($(lk_date %s) - _LK_PROMPT_LAST_START))
-        if ((STATUS)) ||
-            ((SECS > 1)) ||
-            [[ $(type -t "$_LK_PROMPT_LAST") != builtin ]]; then
+    if [[ -n ${_LK_PROMPT+1} ]]; then
+        local elapsed=$(($(lk_timestamp) - _LK_PROMPT_START))
+        # If the last command failed, ran for at least 2 seconds, or is not a
+        # builtin, add a summary line
+        if ((status || elapsed > 1 || ${#_LK_PROMPT[@]} > 1)) ||
+            [[ $(type -t "$_LK_PROMPT_FIRST") != builtin ]]; then
+            # Start with these 26 columns: "Thu May 06 15:02:32 ✔ (  )"
+            local width=26
             # "Thu May 06 15:02:32 "
-            PS+=("\n\[$LK_DIM\]\d \t\[$LK_UNDIM\] ")
-            if ((!STATUS)); then
+            parts[${#parts[@]}]="\n\[$LK_DIM\]\d \t\[$LK_UNDIM\] "
+            if ((!status)); then
                 # "✔"
-                PS+=("\[$LK_GREEN\]"$'\xe2\x9c\x94')
+                parts[${#parts[@]}]="\[$LK_GREEN\]✔"
             else
                 # "✘ returned 1"
-                STR=" returned $STATUS"
-                PS+=("\[$LK_RED\]"$'\xe2\x9c\x98'"$STR")
-                ((LEN += ${#STR}))
+                part=" returned $status"
+                parts[${#parts[@]}]="\[$LK_RED\]✘$part"
+                ((width += ${#part}))
             fi
-            # " after 12s "
-            if ((SECS < 120)); then
-                SECS+=s
+            # " after 12s"
+            if ((elapsed < 120)); then
+                elapsed+=s
             else
-                SECS=$(lk_duration "$SECS")
+                elapsed=$(lk_duration "$elapsed")
             fi
-            STR=" after $SECS "
-            PS+=("$STR\[$LK_DEFAULT$LK_DIM\]")
-            LEN=$((COLUMNS - LEN - ${#STR}))
-            if ((LEN > 0)); then
-                # "( sleep 12; false )"
-                unset IFS
-                PS+=("($(printf ' %s' "${_LK_PROMPT_LAST[@]}" |
-                    lk_prompt_sanitise |
-                    head -c"$LEN") )")
+            part=" after $elapsed"
+            parts[${#parts[@]}]="$part\[$LK_DEFAULT\]"
+            width=$((COLUMNS - width - ${#part}))
+            if ((width > 0)); then
+                # " ( sleep 12; false )"
+                local IFS=' '
+                parts[${#parts[@]}]=" \[$LK_DIM\]( $(
+                    set -- "${_LK_PROMPT[@]}"
+                    { printf '%s' "$1" && shift && { ((!$#)) || printf '; %s' "$@"; }; } |
+                        _lk_prompt_sanitise |
+                        head -c"$width"
+                ) )\[$LK_UNDIM\]"
             fi
             # "\n"
-            PS+=("\[$LK_UNDIM\]\n")
+            parts[${#parts[@]}]="\n"
         fi
-        _LK_PROMPT_LAST=()
+        _LK_PROMPT=()
     fi
     if ((EUID)); then
         # "ubuntu@"
-        PS+=("\[$LK_BOLD$LK_GREEN\]\u@")
+        parts[${#parts[@]}]="\[$LK_BOLD$LK_GREEN\]\u@"
     else
         # "root@"
-        PS+=("\[$LK_BOLD$LK_RED\]\u@")
+        parts[${#parts[@]}]="\[$LK_BOLD$LK_RED\]\u@"
     fi
-    # "host1 ~ "
-    PS+=("\h\[$LK_BLUE\] \w \[$LK_DEFAULT$LK_UNBOLD\]")
-    [[ -z ${LK_PROMPT_TAG:+1} ]] ||
-        PS+=("\[$LK_WHITE$LK_MAGENTA_BG\] \[$LK_BOLD\]${LK_PROMPT_TAG}\[$LK_UNBOLD\] \[$LK_DEFAULT_BG$LK_DEFAULT\] ")
-    IFS=
-    # "$ " or "# "
-    PS1="${PS[*]}\\\$ "
-    _LK_PROMPT_DISPLAYED=1
-    # Remove Byobu's "history -a;history -r;" prefix
+    # "host1 ~"
+    parts[${#parts[@]}]="\h \[$LK_BLUE\]\w\[$LK_DEFAULT$LK_UNBOLD\]"
+    if ((EUID)) && [[ $(type -t __git_ps1) == function ]]; then
+        part=$(GIT_PS1_SHOWCOLORHINTS=1 __git_ps1 '%s')
+        if [[ -n ${part:+1} ]]; then
+            # "(main)"
+            parts[${#parts[@]}]="\[$LK_YELLOW\](\[$LK_DEFAULT\]$part\[$LK_YELLOW\])\[$LK_DEFAULT\]"
+        fi
+    fi
+    if [[ -n ${LK_PROMPT_TAG:+1} ]]; then
+        # " .tag."
+        parts[${#parts[@]}]=" \[$LK_WHITE$LK_MAGENTA_BG\] \[$LK_BOLD\]${LK_PROMPT_TAG}\[$LK_UNBOLD\] \[$LK_DEFAULT_BG$LK_DEFAULT\]"
+    fi
+    local IFS=
+    # " $ " or " # "
+    PS1="${parts[*]} \\\$ "
+    _LK_PROMPT_SEEN=1
+    # Remove `history -a;history -r;` added by Byobu, for example
     PROMPT_COMMAND=_lk_prompt_command
+    # Speaking of Byobu, prevent nested sessions
     [[ ${LC_BYOBU:+1}${BYOBU_TERM:+2} != 2 ]] || export LC_BYOBU=0
 }
 
+# lk_prompt_enable
+#
+# Enable the lk-platform Bash prompt.
 function lk_prompt_enable() {
     eval "$(lk_get_regex NON_PRINTING_REGEX)"
-    eval "function lk_prompt_sanitise() {
+    eval "function _lk_prompt_sanitise() {
     LC_ALL=C sed -E $(
         printf '%q' "s/$NON_PRINTING_REGEX//g; "$'s/.*\r(.)/\\1/'
     ) | tr -d '\\0-\\10\\16-\\37\\177'
 }"
-    unset _LK_PROMPT_DISPLAYED
-    _LK_PROMPT_LAST=()
+    _LK_PROMPT_SEEN=0
+    _LK_PROMPT=()
     PROMPT_COMMAND=_lk_prompt_command
-    trap _lk_prompt_trap DEBUG
+    # On Bash 3.2, DEBUG handlers need to be removed before they can be replaced
+    trap - DEBUG
+    trap _lk_prompt_trap_debug DEBUG
 }

--- a/lib/bash/rc.sh
+++ b/lib/bash/rc.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-unset _LK_PROMPT_DISPLAYED
+unset _LK_PROMPT_SEEN
 
 SH=$(
     set -u

--- a/share/grub/update-grub-arch
+++ b/share/grub/update-grub-arch
@@ -1,19 +1,49 @@
 #!/usr/bin/env bash
 
+# Usage: sudo update-grub [-i|--install]
+
 set -euo pipefail
-lk_fail() { (($1)) && return $1 || return 1; }
-lk_die() { s=$? && printf '%s: %s\n' "$0" "$1" >&2 && lk_fail $s || exit; }
 
-((!EUID)) || lk_die "not running as root"
+function die() {
+    local s=$?
+    printf '%s: %s\n' "${0##*/}" "${1-command failed}" >&2
+    exit $((s ? s : 1))
+}
 
-if [[ ${1-} =~ ^(-i|--install)$ ]]; then
-    grub-install --target=x86_64-efi --efi-directory=/boot --bootloader-id=GRUB
-    # On some systems, GRUB must be installed at the default/fallpack boot path
-    install -Dpv /boot/EFI/GRUB/grubx64.efi /boot/EFI/BOOT/BOOTX64.EFI
-elif (($#)); then
-    lk_die "invalid arguments"
+((!EUID)) || die "not running as root"
+
+install=0
+case "${1-}" in
+-i | --install)
+    install=1
+    shift
+    ;;
+esac
+
+((!$#)) || die "invalid arguments"
+
+if ((install)); then
+    uefi_bits=$(</sys/firmware/efi/fw_platform_size) 2>/dev/null ||
+        die "not running in UEFI mode"
+    if ((uefi_bits == 32)); then
+        target=i386-efi
+        grub_file=grubia32.efi
+        boot_file=BOOTIA32.EFI
+    else
+        target=x86_64-efi
+        grub_file=grubx64.efi
+        boot_file=BOOTX64.EFI
+    fi
+    grub_file=/boot/EFI/GRUB/$grub_file
+    grub-install --target="$target" --efi-directory=/boot --bootloader-id=GRUB &&
+        [[ -f $grub_file ]] &&
+        # Also make GRUB the UEFI "fallback" bootloader
+        install -Dpv "$grub_file" "/boot/EFI/BOOT/$boot_file" ||
+        die "error installing GRUB"
 else
-    printf '%s: skipping grub-install (--install not set)\n' "$0"
+    printf '%s: grub-install skipped (-i, --install not given)\n' "${0##*/}"
 fi
 
 grub-mkconfig -o /boot/grub/grub.cfg
+
+#### Reviewed: 2025-06-20

--- a/share/packages/arch/dev.sh
+++ b/share/packages/arch/dev.sh
@@ -70,6 +70,7 @@ lk_is_virtual || {
         i2c-tools
     )
     AUR_PACKAGES+=(
+        furmark
         geekbench5
     )
     ! lk_system_has_intel_graphics || PAC_PACKAGES+=(

--- a/share/udev/libvirt-guest-tap-unmanaged.rules
+++ b/share/udev/libvirt-guest-tap-unmanaged.rules
@@ -1,0 +1,1 @@
+ACTION=="add|change|move", SUBSYSTEM=="net", ENV{ID_NET_DRIVER}=="tun", ENV{INTERFACE}=="vnet[0-9]*", ENV{NM_UNMANAGED}="1"

--- a/src/lib/bash/core.sh
+++ b/src/lib/bash/core.sh
@@ -1091,6 +1091,17 @@ function lk_base64() {
     fi
 }
 
+# lk_hex [-d]
+function lk_hex() {
+    local decode=0
+    [[ ${1-} != -d ]] || decode=1
+    if ((decode)); then
+        xxd -r -p
+    else
+        xxd -p -c 0
+    fi
+}
+
 if ! lk_is_macos; then
     function lk_full_name() {
         getent passwd "${1:-$EUID}" | cut -d: -f5 | cut -d, -f1

--- a/src/lib/bash/linode.sh.d/80-hosting.sh
+++ b/src/lib/bash/linode.sh.d/80-hosting.sh
@@ -100,7 +100,7 @@ Example:
         $'\n'"$(lk_fold_quote_options -120 linode-cli "${ARGS[@]##ssh-??? * }")"
     lk_confirm "Proceed?" Y || return
     lk_tty_print "${VERBS[0]} Linode"
-    FILE=/tmp/$FUNCNAME-$1-$(lk_date %s).json
+    FILE=/tmp/$FUNCNAME-$1-$(lk_timestamp).json
     LINODES=$(linode-cli "${ARGS[@]}" | tee "$FILE") ||
         lk_pass rm -f "$FILE" || return
     lk_linode_flush_cache


### PR DESCRIPTION
- Add 32-bit UEFI support to GRUB install helper
- Add `udev` rule to prevent Network Manager from managing libvirt guest TAP devices, triggering downstream `ntpd` restart failure
- Add `lk_hex` function
